### PR TITLE
Use crypto.randomBytes() for token generation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,9 +59,13 @@ marshal.domain = function domain(name, sponsor) {
     };
     var generateToken = function generateToken() {
         try {
-            return require('crypto').randomBytes(20).toString('base64');
+            return require('crypto').randomBytes(42).toString('base64');
         } catch (exception) {
-            // TODO: this can happen if we are out of entropy, deal with it
+            // FIXME: if the system runs out of entropy, an exception will be
+            //        thrown; we need to define system behavior when we are out
+            //        of entropy, remembering that the entire OS crypto activity
+            //        (including any encrypted network traffic) will grind to
+            //        a halt while waiting for entropy to be available
             throw exception;
         }
     };


### PR DESCRIPTION
Some time fairly recently I learned that we can use `crypto.randomBytes(size)` to generate cryptographically secure random bytes. As `sha1` generates a 20 byte hash, using `crypto.randomBytes(size)` might be more straightforward way of doing this.

As these tokens will end up exposed to the outside world, we may need to consider more than 160 bits (20 bytes) and instead use purely random tokens where the token space should be large enough so that no matter how many tokens we generate, they will still be sparsely distributed in the entirety of the token space itself (to make guessing them unfeasible even with billions/trillions/++ of them in existence). For example, 41 bytes would give us 328 bits, which would be a space large enough to enumerate all atoms in the observable universe. Using `crypto.randomBytes(size)` paves the way for us to tweak the token space as necessary.

[crypto.randomBytes(size)](http://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback)
