### PR TITLE
Support replacing randomBytes implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ stepping.eventLoop({
   * [domain.remoteToLocal(token)](#domainremotetolocaltoken)
   * [domain.bindLocal(token, actor)](#bindlocaltokenactor)
   * [domain.receptionist(message)](#domainreceptionistmessage)
+  * [marshal.randomBytes(size\[, callback\])](#marshalrandombytessize-callback)
 
 ### marshal.router([defaultRoute])
 
@@ -197,3 +198,10 @@ Associate a `token` with a local `actor`. Future calls to `domain.localToRemote`
     * `json`: _String_ marshal-encoded message content.
 
 Decodes `json` using [domain.decode(json)](#domaindecodejson) and sends the result as a message to the actor designated by decoding `address` using [domain.remoteToLocal(token)](#domainremotetolocaltoken).  The original `message` encoding is called _transport_ format.
+
+### marshal.randomBytes(size[, callback])
+
+  * `size`: _Integer_ Number of bytes to generate.
+  * `callback`: _Function_ _(Default: undefined)_ `function (error, buffer) {}` Callback to invoke once bytes are generated.
+
+Exposed to allow for replacement in case of need for deterministic testing.

--- a/examples/randomBytes.js
+++ b/examples/randomBytes.js
@@ -1,0 +1,98 @@
+/*
+
+randomBytes.js - Bring-your-own randomBytes example
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Tristan Slominski
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";
+
+var Generator = require("deterministic-pseudorandombytes");
+var generator = new Generator({seed: "foo"});
+var marshal = require("../index.js");
+marshal.randomBytes = generator.randomBytes.bind(generator);
+var tart = require("tart");
+var transport = require("tart-transport-udp");
+
+var sponsor = tart.minimal();
+
+var send = sponsor(transport.sendBeh);
+
+var domain0 = marshal.domain("udp://localhost:10000/", send);
+var domain1 = marshal.domain("udp://localhost:10001/", send);
+
+var pingBeh = function pingBeh(message) {
+    console.dir(message);
+    if (message.value === undefined) {
+        var pong = message.pong;
+        pong({ping: this.self, pong: pong, value: "pinging"});
+    } else {
+        console.log("ping", message.value);
+        console.log("(ping === message.ping)", ping === message.ping);
+        closeDomain0();
+        closeDomain1();
+    }
+};
+
+var pongBeh = function pongBeh(message) {
+    var ping = message.ping;
+    ping({ping: ping, pong: this.self, value: "ponging"});
+    console.log("pong", message.value);
+};
+
+var ping = sponsor(pingBeh);
+var pong = sponsor(pongBeh);
+
+var bootstrapBeh = function bootstrapBeh(pingToken) {
+    var pingProxy = domain1.remoteToLocal(pingToken);
+    pingProxy({pong: pong});
+};
+
+var listenAcks = 0;
+var bothAck = sponsor(function bothAckBeh(message) {
+    console.log("udp server listening", message);
+    listenAcks++;
+    if (listenAcks == 2) {
+        // both servers are listening, bootstrap and start ping-pong
+        var pingToken = domain0.localToRemote(ping);
+        sponsor(bootstrapBeh)(pingToken);
+    }
+});
+
+var domain0TcpCaps = transport.server(domain0.receptionist);
+var domain1TcpCaps = transport.server(domain1.receptionist);
+
+// start domain 0 server
+var listenDomain0 = sponsor(domain0TcpCaps.listenBeh);
+var closeDomain0 = sponsor(domain0TcpCaps.closeBeh);
+
+listenDomain0({host: "localhost", port: 10000, ok: bothAck});
+
+// start domain 1 server
+var listenDomain1 = sponsor(domain1TcpCaps.listenBeh);
+var closeDomain1 = sponsor(domain1TcpCaps.closeBeh);
+
+listenDomain1({host: "localhost", port: 10001, ok: bothAck});

--- a/index.js
+++ b/index.js
@@ -30,9 +30,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 "use strict";
 
+var crypto = require("crypto");
 var marshal = module.exports;
 
-marshal.randomBytes = require("crypto").randomBytes;
+marshal.randomBytes = crypto.randomBytes;
 
 marshal.defaultRoute = function route(message) {
     throw Error('No route for ' + message.address);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ index.js - "tart-marshal": Send messages between memory domains (tart module)
 
 The MIT License (MIT)
 
-Copyright (c) 2013 Dale Schumacher
+Copyright (c) 2013-2016 Dale Schumacher, Tristan Slominski
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 var marshal = module.exports;
 
+marshal.randomBytes = require("crypto").randomBytes;
+
 marshal.defaultRoute = function route(message) {
     throw Error('No route for ' + message.address);
 };
@@ -98,18 +100,9 @@ marshal.domain = function domain(name, transport) {
         return self.name + '#' + generateCapability();
     };
     var generateCapability = function generateCapability() {
-        try {
-            return require('crypto').randomBytes(42).toString('base64');
-        } catch (exception) {
-            // FIXME: if the system runs out of entropy, an exception will be thrown;
-            //        we need to define system behavior when we are out of entropy,
-            //        remembering that the entire OS crypto activity
-            //        (including any encrypted network traffic)
-            //        will grind to a halt while waiting for entropy to be available
-            throw exception;
-        }
+        return marshal.randomBytes(42).toString('base64');
     };
-    
+
     var remoteToLocal = function remoteToLocal(remote) {
         var local = tokenMap[remote];
         if (local === undefined) {
@@ -171,7 +164,7 @@ marshal.domain = function domain(name, transport) {
     var decodeString = function decodeString(value) {
         return value.slice(1);
     };
-    
+
     var generateName = function generateName(name) {
         if (!name) {
             name = 'ansible://' + generateCapability() + '/';

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.3.1",
   "description": "Send messages between memory domains (tart module)",
   "scripts": {
-    "all-examples": "npm run http && npm run https && npm run tcp && npm run tls && npm run udp",
+    "all-examples": "npm run http && npm run https && npm run tcp && npm run tls && npm run udp && npm run random-bytes",
     "http": "node examples/http.js",
     "https": "node examples/https.js",
     "inject-examples": "node scripts/injectExamples.js",
+    "random-bytes": "node examples/randomBytes.js",
     "readme": "node examples/readme.js",
     "tcp": "node examples/tcp.js",
     "test": "node scripts/test.js",
@@ -15,6 +16,7 @@
   },
   "main": "index.js",
   "devDependencies": {
+    "deterministic-pseudorandombytes": "0.1.0",
     "tart-stepping": "0.2.x",
     "tart-transport-http": "0.1.0",
     "tart-transport-https": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "tart-transport-tcp": "0.1.0",
     "tart-transport-tls": "0.1.1",
     "tart-transport-udp": "0.1.0",
-    "nodeunit": "0.8.x"
+    "nodeunit": "0.10.x"
   },
   "dependencies": {
     "tart-stepping": "0.2.x",
-    "tart": "0.2.x"
+    "tart": "0.3.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In order to enable support for deterministic testing, allow for `randomBytes` replacement.
Updated dependencies.